### PR TITLE
Add support for URLs with double slashes in their path

### DIFF
--- a/akka-http/src/main/scala/fr/davit/capturl/akka/http/UriConverters.scala
+++ b/akka-http/src/main/scala/fr/davit/capturl/akka/http/UriConverters.scala
@@ -77,6 +77,7 @@ trait UriConverters {
       case Empty                         => akkaPath
       case Slash(tail)                   => akkaPathBuilder(tail, Uri.Path.Slash(akkaPath))
       case Segment(segment, Empty)       => Uri.Path.Segment(segment, akkaPath)
+      case Segment("", Slash(tail))      => akkaPathBuilder(tail, Uri.Path.Slash(akkaPath))
       case Segment(segment, Slash(tail)) => akkaPathBuilder(tail, Uri.Path.Slash(Uri.Path.Segment(segment, akkaPath)))
     }
     akkaPathBuilder(path.reverse, Uri.Path.Empty)

--- a/akka-http/src/test/scala/fr/davit/capturl/akka/http/UriConvertersSpec.scala
+++ b/akka-http/src/test/scala/fr/davit/capturl/akka/http/UriConvertersSpec.scala
@@ -196,8 +196,8 @@ class UriConvertersSpec extends FlatSpec with Matchers {
 
     {
       // path containing double slashes
-      val uri = Uri("https://example.com/client/https://test.co.uk/wp/home.jpeg")
-      val iri = Iri("https://example.com/client/https://test.co.uk/wp/home.jpeg")
+      val uri = Uri("https://example.com/dir//file.jpeg")
+      val iri = Iri("https://example.com/dir//file.jpeg")
       (uri: Iri) shouldBe iri
       (iri: Uri) shouldBe uri
     }

--- a/akka-http/src/test/scala/fr/davit/capturl/akka/http/UriConvertersSpec.scala
+++ b/akka-http/src/test/scala/fr/davit/capturl/akka/http/UriConvertersSpec.scala
@@ -127,6 +127,14 @@ class UriConvertersSpec extends FlatSpec with Matchers {
       (akkaPath: Path) shouldBe path
       (path: Uri.Path) shouldBe akkaPath
     }
+
+    // paths containing double slashes
+    {
+      val akkaPath = Uri.Path.Segment("directory", Uri.Path.Slash(Uri.Path.Slash(Uri.Path.Segment("file.html", Uri.Path.Empty))))
+      val path = Segment("directory", Slash(Slash(Segment("file.html"))))
+      (akkaPath: Path) shouldBe path
+      (path: Uri.Path) shouldBe akkaPath
+    }
   }
 
   it should "convert query" in {

--- a/akka-http/src/test/scala/fr/davit/capturl/akka/http/UriConvertersSpec.scala
+++ b/akka-http/src/test/scala/fr/davit/capturl/akka/http/UriConvertersSpec.scala
@@ -201,5 +201,13 @@ class UriConvertersSpec extends FlatSpec with Matchers {
       (uri: Iri) shouldBe iri
       (iri: Uri) shouldBe uri
     }
+
+    {
+      // path containing double slashes
+      val uri = Uri("https://cdn.shotpixel.ai/client/q_glossy,ret_img,w_419/https://releastyuk.co.uk/wp-content/uploads/2019/08/home_imprments.jpeg")
+      val iri = Iri("https://cdn.shotpixel.ai/client/q_glossy,ret_img,w_419/https://releastyuk.co.uk/wp-content/uploads/2019/08/home_imprments.jpeg")
+      (uri: Iri) shouldBe iri
+      (iri: Uri) shouldBe uri
+    }
   }
 }

--- a/akka-http/src/test/scala/fr/davit/capturl/akka/http/UriConvertersSpec.scala
+++ b/akka-http/src/test/scala/fr/davit/capturl/akka/http/UriConvertersSpec.scala
@@ -127,14 +127,6 @@ class UriConvertersSpec extends FlatSpec with Matchers {
       (akkaPath: Path) shouldBe path
       (path: Uri.Path) shouldBe akkaPath
     }
-
-    // paths containing double slashes
-    {
-      val akkaPath = Uri.Path.Segment("directory", Uri.Path.Slash(Uri.Path.Slash(Uri.Path.Segment("file.html", Uri.Path.Empty))))
-      val path = Segment("directory", Slash(Slash(Segment("file.html"))))
-      (akkaPath: Path) shouldBe path
-      (path: Uri.Path) shouldBe akkaPath
-    }
   }
 
   it should "convert query" in {

--- a/akka-http/src/test/scala/fr/davit/capturl/akka/http/UriConvertersSpec.scala
+++ b/akka-http/src/test/scala/fr/davit/capturl/akka/http/UriConvertersSpec.scala
@@ -196,8 +196,8 @@ class UriConvertersSpec extends FlatSpec with Matchers {
 
     {
       // path containing double slashes
-      val uri = Uri("https://cdn.shotpixel.ai/client/q_glossy,ret_img,w_419/https://releastyuk.co.uk/wp-content/uploads/2019/08/home_imprments.jpeg")
-      val iri = Iri("https://cdn.shotpixel.ai/client/q_glossy,ret_img,w_419/https://releastyuk.co.uk/wp-content/uploads/2019/08/home_imprments.jpeg")
+      val uri = Uri("https://example.com/client/https://test.co.uk/wp/home.jpeg")
+      val iri = Iri("https://example.com/client/https://test.co.uk/wp/home.jpeg")
       (uri: Iri) shouldBe iri
       (iri: Uri) shouldBe uri
     }


### PR DESCRIPTION
We came across some URLs which have double slashes in their path. For example: `https://cdn.shortpixel.ai/client/q_glossy,ret_img,w_419/https://releasemyequityuk.co.uk/wp-content/uploads/2019/08/home_improvements.jpeg`.

The current implementation fixes the issue and allows the implicit conversion of the IRI to an Akka URI. 

I also thought about replacing double slashes with single ones; this should work if the double slashes are used as segment delimiters and we have an empty segment. But in this example the whole segment is `https://releasemyequityuk.co.uk`, it's not three separate segments, with the middle one being an empty string. Replacing the double slash with a single one leads to a different page.

I'm open to suggestions if there is a better way to differentiate between slashes as segment delimiters and (double) slashes as segment content.