### PR TITLE
Specify UTF8 charset when parsing percent encoded characters

### DIFF
--- a/src/main/scala/fr/davit/capturl/parsers/RichStringBuilding.scala
+++ b/src/main/scala/fr/davit/capturl/parsers/RichStringBuilding.scala
@@ -41,7 +41,7 @@ trait RichStringBuilding extends StringBuilding { this: Parser =>
   protected def `pct-encoded`: Rule0 = rule {
     ('%' ~ capture(HexDigit ~ HexDigit)).+ ~> { hexes: Seq[String] =>
       val bytes = hexes.map(hex => Integer.parseInt(hex, 16).toByte)
-      appendSB(new String(bytes.toArray))
+      appendSB(new String(bytes.toArray, UTF8))
     }
   }
 

--- a/src/test/scala/fr/davit/capturl/parsers/AuthorityParserSpec.scala
+++ b/src/test/scala/fr/davit/capturl/parsers/AuthorityParserSpec.scala
@@ -33,6 +33,7 @@ class AuthorityParserSpec extends FlatSpec with Matchers {
     parse("@host") shouldBe Credentials("") -> "@host"
     parse("userinfo@host") shouldBe Credentials("userinfo") -> "@host"
     parse("%75%73%65%72%69%6E%66%6F@host") shouldBe Credentials("userinfo") -> "@host"
+    parse("%C3%B6@host") shouldBe Credentials("ö") -> "@host"
   }
 
   it should "parse port" in new PortFixture {

--- a/src/test/scala/fr/davit/capturl/parsers/FragmentParserSpec.scala
+++ b/src/test/scala/fr/davit/capturl/parsers/FragmentParserSpec.scala
@@ -16,6 +16,7 @@ class FragmentParserSpec extends FlatSpec with Matchers {
   "FragmentParser" should "parse fragment" in new Fixture {
     parse("") shouldBe Fragment.Identifier("")                     -> ""
     parse("identifier") shouldBe Fragment.Identifier("identifier") -> ""
+    parse("%C3%B6") shouldBe Fragment.Identifier("ö")              -> ""
 
     // relax parsing
     parse("fragment with spaces") shouldBe Fragment.Identifier("fragment with spaces") -> ""

--- a/src/test/scala/fr/davit/capturl/parsers/PathParserSpec.scala
+++ b/src/test/scala/fr/davit/capturl/parsers/PathParserSpec.scala
@@ -21,6 +21,7 @@ class PathParserSpec extends FlatSpec with Matchers {
     parse("relative/path?query") shouldBe Segment("relative", Slash(Segment("path")))         -> "?query"
     parse("directory/?query") shouldBe Path.Segment("directory", Slash())                     -> "?query"
     parse("/one//path?query") shouldBe Slash(Segment("one", Slash(Slash(Segment("path")))))   -> "?query"
+    parse("/%C3%B6?query") shouldBe Slash(Segment("ö"))                                       -> "?query"
 
     // relax parsing
     parse("/path with spaces?query") shouldBe Slash(Segment("path with spaces")) -> "?query"

--- a/src/test/scala/fr/davit/capturl/parsers/QueryParserSpec.scala
+++ b/src/test/scala/fr/davit/capturl/parsers/QueryParserSpec.scala
@@ -16,6 +16,7 @@ class QueryParserSpec extends FlatSpec with Matchers {
   "QueryParser" should "parse query" in new Fixture {
     parse("#fragment") shouldBe Query.Part("") -> "#fragment"
     parse("key1=val1&key2#fragment") shouldBe Query.Part("key1", Some("val1"), Query.Part("key2")) -> "#fragment"
+    parse("%C3%B6=val1#fragment") shouldBe Query.Part("ö", Some("val1"))                           -> "#fragment"
 
     // relax parsing
     parse("key with+spaces#fragment") shouldBe Query.Part("key with spaces") -> "#fragment"


### PR DESCRIPTION
Currently, parsing percent-encoded URLs does not work when the default charset on the JVM is not UTF8.